### PR TITLE
feat: Integrate Playgama SDK Leaderboard Feature

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,6 +15,21 @@
                 background-repeat: no-repeat;
                 background-position: center;
             }
+            #showLeaderboardBtn {
+                position: absolute;
+                top: 20px;
+                left: 20px;
+                padding: 10px 15px;
+                background-color: #007bff;
+                color: white;
+                border: none;
+                border-radius: 5px;
+                cursor: pointer;
+                z-index: 1000; /* Ensure it's above the canvas */
+            }
+            #showLeaderboardBtn:hover {
+                background-color: #0056b3;
+            }
             #canvas-container {
                 width: 100vw;
                 height: 100vh;
@@ -33,7 +48,9 @@
     <body>
         <div id="canvas-container">
             <div id="canvas"></div>
+            <button id="showLeaderboardBtn">Show Leaderboard</button>
         </div>
+        <script src="./playgama_leaderboard.js"></script>
         <script src="bundle.js"></script>
     </body>
 </html>

--- a/playgama_leaderboard.js
+++ b/playgama_leaderboard.js
@@ -1,0 +1,169 @@
+// Playgama Leaderboard API functions
+
+const DEFAULT_LEADERBOARD_NAME = "global_high_scores";
+
+/**
+ * Checks if the leaderboard functionality is supported by the bridge.
+ * @returns {boolean} True if supported, false otherwise.
+ */
+function isLeaderboardSupported() {
+  console.log("Checking for leaderboard support...");
+  if (typeof bridge !== 'undefined' && bridge.leaderboard) {
+    return bridge.leaderboard.isSupported;
+  } else {
+    console.error("Bridge or bridge.leaderboard is not available.");
+    return false;
+  }
+}
+
+/**
+ * Checks if native popups for leaderboards are supported.
+ * @returns {boolean} True if native popups are supported, false otherwise.
+ */
+function isNativePopupSupported() {
+  console.log("Checking for native popup support...");
+  if (typeof bridge !== 'undefined' && bridge.leaderboard) {
+    return bridge.leaderboard.isNativePopupSupported;
+  } else {
+    console.error("Bridge or bridge.leaderboard is not available.");
+    return false;
+  }
+}
+
+/**
+ * Sets the player's score on a specific leaderboard.
+ * @param {number} score - The score to set.
+ * @param {string} leaderboardName - The name of the leaderboard.
+ */
+function setPlayerScore(score, leaderboardName) {
+  console.log(`Setting score ${score} for leaderboard ${leaderboardName}`);
+  if (typeof bridge === 'undefined' || !bridge.leaderboard) {
+    console.error("Bridge or bridge.leaderboard is not available. Cannot set score.");
+    return;
+  }
+
+  let options = {
+    score: score,
+    leaderboardName: leaderboardName
+  };
+
+  // Platform-specific options based on Playgama documentation
+  switch (bridge.platform.id) {
+    case 'GAMEDISTRIBUTION':
+      // No specific options mentioned for Gamedistribution in this context
+      break;
+    case 'GAMEPIX':
+      // No specific options mentioned for GamePix
+      break;
+    // Add other platforms as needed
+    default:
+      console.warn(`Platform ${bridge.platform.id} might have specific options for setPlayerScore.`);
+  }
+
+  console.log("Options for bridge.leaderboard.setScore:", options);
+  // Actual call would be: bridge.leaderboard.setScore(options);
+}
+
+/**
+ * Gets the player's score from a specific leaderboard.
+ * @param {string} leaderboardName - The name of the leaderboard.
+ */
+function getPlayerScore(leaderboardName) {
+  console.log(`Getting player score for leaderboard ${leaderboardName}`);
+  if (typeof bridge === 'undefined' || !bridge.leaderboard) {
+    console.error("Bridge or bridge.leaderboard is not available. Cannot get score.");
+    return;
+  }
+
+  let options = {
+    leaderboardName: leaderboardName
+  };
+
+  // Platform-specific options based on Playgama documentation
+  switch (bridge.platform.id) {
+    case 'GAMEDISTRIBUTION':
+      // Example: Gamedistribution might require a specific format or additional parameters
+      // options.gdSpecificParam = 'value';
+      break;
+    case 'GAMEPIX':
+      // options.interval = 'daily'; // Example if GamePix needs an interval
+      break;
+    // Add other platforms as needed
+    default:
+      console.warn(`Platform ${bridge.platform.id} might have specific options for getPlayerScore.`);
+  }
+
+  console.log("Options for bridge.leaderboard.getScore:", options);
+  // Actual call would be: bridge.leaderboard.getScore(options);
+}
+
+/**
+ * Shows the leaderboard.
+ * Uses native popup if supported, otherwise fetches entries.
+ * @param {string} leaderboardName - The name of the leaderboard to show.
+ */
+function showLeaderboard(leaderboardName) {
+  console.log(`Showing leaderboard ${leaderboardName}`);
+  if (typeof bridge === 'undefined' || !bridge.leaderboard) {
+    console.error("Bridge or bridge.leaderboard is not available. Cannot show leaderboard.");
+    return;
+  }
+
+  if (isNativePopupSupported()) {
+    console.log("Native popup is supported. Preparing to show native leaderboard popup.");
+    let options = {
+      leaderboardName: leaderboardName
+    };
+    // Platform-specific options for showNativePopup
+    switch (bridge.platform.id) {
+      case 'GAMEPIX':
+        // options.interval = 'daily'; // Example
+        break;
+      // Add other platforms as needed
+      default:
+        console.warn(`Platform ${bridge.platform.id} might have specific options for showNativePopup.`);
+    }
+    console.log("Options for bridge.leaderboard.showNativePopup:", options);
+    // Actual call would be: bridge.leaderboard.showNativePopup(options);
+  } else {
+    console.log("Native popup not supported. Preparing to get leaderboard entries.");
+    let options = {
+      leaderboardName: leaderboardName
+      // Potentially add other options like limit, offset, etc.
+    };
+    // Platform-specific options for getEntries
+    switch (bridge.platform.id) {
+      case 'GAMEDISTRIBUTION':
+        // options.limit = 10; // Example
+        break;
+      // Add other platforms as needed
+      default:
+        console.warn(`Platform ${bridge.platform.id} might have specific options for getEntries.`);
+    }
+    console.log("Options for bridge.leaderboard.getEntries:", options);
+    // Actual call would be: bridge.leaderboard.getEntries(options);
+  }
+}
+
+/**
+ * Placeholder function to handle end of game logic.
+ * This function will call setPlayerScore with a default leaderboard name.
+ * @param {number} score - The player's final score.
+ */
+function handleEndOfGame(score) {
+  console.log(`Game ended with score: ${score}. Setting score on default leaderboard.`);
+  setPlayerScore(score, DEFAULT_LEADERBOARD_NAME);
+}
+
+// Event listener for DOMContentLoaded to attach click handler for the leaderboard button
+document.addEventListener('DOMContentLoaded', () => {
+  const leaderboardButton = document.getElementById('showLeaderboardBtn');
+  if (leaderboardButton) {
+    leaderboardButton.addEventListener('click', () => {
+      console.log('Show Leaderboard button clicked');
+      showLeaderboard(DEFAULT_LEADERBOARD_NAME);
+    });
+  } else {
+    console.error('Leaderboard button #showLeaderboardBtn not found.');
+  }
+});


### PR DESCRIPTION
Adds initial support for Playgama SDK leaderboards.

Key changes:
- Created `playgama_leaderboard.js` with wrapper functions for Playgama leaderboard SDK interactions (isSupported, setScore, getScore, showLeaderboard, etc.). These functions include logging for simulated SDK calls and error handling for when the `bridge` object is not available.
- Added a 'Show Leaderboard' button to `index.html` and styled it.
- The button is wired to call the `showLeaderboard()` function from `playgama_leaderboard.js`.
- Introduced a placeholder function `handleEndOfGame(score)` in `playgama_leaderboard.js` to demonstrate how `setPlayerScore()` would be called from game logic.
- Included `playgama_leaderboard.js` in `index.html` before the main `bundle.js`.

This provides the basic structure for leaderboard integration. Actual calls to the Playgama SDK (`bridge.leaderboard.*`) are commented out or logged, as the SDK is not present in the development environment. Further integration will require linking these functions with the game's score management system within `bundle.js` and testing within the Playgama environment.