### PR TITLE
feat: Display dummy leaderboard popup and use dummy data

### DIFF
--- a/playgama_leaderboard.js
+++ b/playgama_leaderboard.js
@@ -97,9 +97,96 @@ function getPlayerScore(leaderboardName) {
   // Actual call would be: bridge.leaderboard.getScore(options);
 }
 
+// Styles for the dummy leaderboard popup
+const popupStyles = {
+  container: "position: fixed; top: 50%; left: 50%; transform: translate(-50%, -50%); background-color: white; border: 2px solid #4A90E2; padding: 25px; z-index: 1001; min-width: 320px; max-width: 90%; box-shadow: 0 5px 15px rgba(0,0,0,0.3); border-radius: 10px; font-family: Arial, sans-serif;",
+  title: "font-size: 1.8em; margin-bottom: 15px; text-align: center; color: #333;",
+  closeButton: "position: absolute; top: 10px; right: 15px; cursor: pointer; font-size: 1.5em; color: #aaa; line-height: 1;",
+  list: "list-style: none; padding: 0; margin-top: 10px;",
+  listItem: "display: flex; justify-content: space-between; padding: 8px 0; border-bottom: 1px solid #eee;",
+  listItemLast: "display: flex; justify-content: space-between; padding: 8px 0; border-bottom: none;",
+  rank: "font-weight: bold; min-width: 30px; color: #4A90E2;",
+  name: "flex-grow: 1; margin-left: 10px; margin-right: 10px; color: #555;",
+  score: "font-weight: bold; color: #E87A00;"
+};
+
+const DUMMY_LEADERBOARD_POPUP_ID = 'dummyLeaderboardPopup';
+
+/**
+ * Displays a dummy leaderboard popup on the screen.
+ * @param {string} leaderboardName - The name of the leaderboard to display.
+ */
+function displayDummyLeaderboard(leaderboardName) {
+  console.log(`Displaying dummy leaderboard for: ${leaderboardName}`);
+
+  // Remove existing popup if any
+  const existingPopup = document.getElementById(DUMMY_LEADERBOARD_POPUP_ID);
+  if (existingPopup) {
+    existingPopup.remove();
+  }
+
+  // Main container
+  const popup = document.createElement('div');
+  popup.id = DUMMY_LEADERBOARD_POPUP_ID;
+  popup.style.cssText = popupStyles.container;
+
+  // Title
+  const title = document.createElement('h2');
+  title.textContent = `Leaderboard: ${leaderboardName}`;
+  title.style.cssText = popupStyles.title;
+  popup.appendChild(title);
+
+  // Close button
+  const closeButton = document.createElement('span');
+  closeButton.innerHTML = '&times;'; // 'X' character
+  closeButton.style.cssText = popupStyles.closeButton;
+  closeButton.onclick = () => popup.remove();
+  popup.appendChild(closeButton);
+
+  // Leaderboard list
+  const list = document.createElement('ul');
+  list.style.cssText = popupStyles.list;
+
+  // Dummy data
+  const dummyPlayers = [
+    { rank: 1, name: "PlayerOne", score: 10000 },
+    { rank: 2, name: "PlayerTwo", score: 9500 },
+    { rank: 3, name: "PlayerThree", score: 8800 },
+    { rank: 4, name: "PlayerFour", score: 7200 },
+    { rank: 5, name: "PlayerFive", score: 6500 },
+    { rank: 6, name: "PlayerSix", score: 5000 },
+  ];
+
+  dummyPlayers.forEach((player, index) => {
+    const listItem = document.createElement('li');
+    listItem.style.cssText = (index === dummyPlayers.length - 1) ? popupStyles.listItemLast : popupStyles.listItem;
+
+    const rankSpan = document.createElement('span');
+    rankSpan.textContent = player.rank;
+    rankSpan.style.cssText = popupStyles.rank;
+
+    const nameSpan = document.createElement('span');
+    nameSpan.textContent = player.name;
+    nameSpan.style.cssText = popupStyles.name;
+
+    const scoreSpan = document.createElement('span');
+    scoreSpan.textContent = player.score;
+    scoreSpan.style.cssText = popupStyles.score;
+
+    listItem.appendChild(rankSpan);
+    listItem.appendChild(nameSpan);
+    listItem.appendChild(scoreSpan);
+    list.appendChild(listItem);
+  });
+
+  popup.appendChild(list);
+  document.body.appendChild(popup);
+}
+
+
 /**
  * Shows the leaderboard.
- * Uses native popup if supported, otherwise fetches entries.
+ * Uses native popup if supported, otherwise displays a dummy leaderboard.
  * @param {string} leaderboardName - The name of the leaderboard to show.
  */
 function showLeaderboard(leaderboardName) {
@@ -110,38 +197,17 @@ function showLeaderboard(leaderboardName) {
   }
 
   if (isNativePopupSupported()) {
-    console.log("Native popup is supported. Preparing to show native leaderboard popup.");
-    let options = {
-      leaderboardName: leaderboardName
-    };
-    // Platform-specific options for showNativePopup
-    switch (bridge.platform.id) {
-      case 'GAMEPIX':
-        // options.interval = 'daily'; // Example
-        break;
-      // Add other platforms as needed
-      default:
-        console.warn(`Platform ${bridge.platform.id} might have specific options for showNativePopup.`);
-    }
-    console.log("Options for bridge.leaderboard.showNativePopup:", options);
-    // Actual call would be: bridge.leaderboard.showNativePopup(options);
+    // Even if native is supported, we call the dummy for testing in this environment.
+    // In a real scenario, you might only call bridge.leaderboard.showNativePopup(options);
+    console.log("Native popup is supported. Attempting to show native. Displaying dummy leaderboard for testing.");
+    // Example of what might have been logged or called:
+    // let options = { leaderboardName: leaderboardName };
+    // console.log("Options for bridge.leaderboard.showNativePopup:", options);
+    // bridge.leaderboard.showNativePopup(options);
+    displayDummyLeaderboard(leaderboardName);
   } else {
-    console.log("Native popup not supported. Preparing to get leaderboard entries.");
-    let options = {
-      leaderboardName: leaderboardName
-      // Potentially add other options like limit, offset, etc.
-    };
-    // Platform-specific options for getEntries
-    switch (bridge.platform.id) {
-      case 'GAMEDISTRIBUTION':
-        // options.limit = 10; // Example
-        break;
-      // Add other platforms as needed
-      default:
-        console.warn(`Platform ${bridge.platform.id} might have specific options for getEntries.`);
-    }
-    console.log("Options for bridge.leaderboard.getEntries:", options);
-    // Actual call would be: bridge.leaderboard.getEntries(options);
+    console.log("Native popup not supported. Displaying dummy leaderboard.");
+    displayDummyLeaderboard(leaderboardName);
   }
 }
 


### PR DESCRIPTION
I've implemented a visual leaderboard popup with hardcoded dummy data for testing and UI preview purposes.

Key changes:
- I added a `displayDummyLeaderboard(leaderboardName)` function in `playgama_leaderboard.js`. This function dynamically creates and styles an HTML popup to display a list of dummy player scores.
- The popup includes a title, a list of 6 dummy players (rank, name, score), and a functional close button.
- I used CSS-in-JS (`popupStyles`) for styling the popup elements.
- I modified `showLeaderboard(leaderboardName)`:
    - If native popups are (theoretically) supported, it logs this but still calls `displayDummyLeaderboard` for testing in the current environment.
    - If native popups are not supported, it directly calls `displayDummyLeaderboard`.
    - I removed old logging for `getEntries` or `showNativePopup` options as they are now handled by the dummy display logic.
- The existing 'Show Leaderboard' button in `index.html` will now trigger this dummy popup.

This change allows for immediate visual feedback on the leaderboard feature without requiring a live Playgama SDK environment.