### PR TITLE
Hide campaign button and text via CSS in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,6 +44,10 @@
             }
         </style>
         <script src="./jiogames_sp_wrapper.js"></script>
+        <style>
+            #campaign_button { display: none !important; }
+            #campaign_text { display: none !important; }
+        </style>
     </head>
     <body>
         <div id="canvas-container">


### PR DESCRIPTION
My initial goal was to remove the campaign section. The campaign UI is dynamically generated by JavaScript in `bundle.js`. My attempts to modify `bundle.js` directly to prevent the creation or display of campaign elements were unsuccessful due to the complexity of the `eval()`'d webpack modules and some limitations I encountered.

This commit implements an alternative solution:
- I added a `<style>` block to `index.html`.
- This style block includes CSS rules to set `display: none !important;` for the `#campaign_button` and `#campaign_text` elements.

This change effectively hides the entry point to the campaign mode from you. While the elements are still technically created by the JavaScript, they are not rendered. Testing the visual outcome and potential JavaScript errors fully was not possible due to some limitations I encountered, but this CSS-based approach is generally robust for hiding elements.