### PR TITLE
Fix: Constrain width of repurposed Leaderboard button

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,6 +20,8 @@
                 top: 58%;
                 left: 24%;
                 width: 52%;
+                max-width: 400px; /* Added */
+                min-width: 180px; /* Added */
                 height: 8%;
                 transform: translateY(-50%);
                 background-image: url(assets/Button_Y.png);


### PR DESCRIPTION
This commit addresses your feedback that the "LEADERBOARD" button (which was formerly the Campaign button and is the restyled `#showLeaderboardBtn`) was expanding excessively when the screen was stretched.

Changes in `index.html`:
- The CSS for `#showLeaderboardBtn` has been updated to include:
    - `max-width: 400px;`
    - `min-width: 180px;`
- These are added to the existing styles you provided which include `width: 52%;`. The button will now respect these min/max width constraints, preventing it from becoming too wide on large screens or too narrow on small screens.
- All other styles for `#showLeaderboardBtn` (positioning, height, background image, text content set by script, etc.) remain as per the previous specifications you provided.
- The original `#campaign_button` and `#campaign_text` elements remain hidden via `display: none !important;`.

This change aims to provide a more consistent button width across different screen sizes. The button's text (`font-size` and `line-height`) continues to use `vh` units, which may result in text scaling differently from the button's constrained size under certain aspect ratios.