### PR TITLE
Refactor: Allow your CSS for #showLeaderboardBtn functionality

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,35 +16,11 @@
                 background-position: center;
             }
             #showLeaderboardBtn {
-                position: absolute;
-                top: 58%;
-                left: 24%;
-                width: 52%;
-                max-width: 400px;
-                min-width: 180px;
-                height: 8%;
-                transform: translateY(-50%);
-                background-image: url(assets/Button_Y.png);
-                background-size: 100% 100%;
-                background-repeat: no-repeat;
-                background-position: center;
-                border: none;
-                text-align: center;
-                font-size: 2vh;
-                font-weight: bold;
-                line-height: 10vh;
-                color: rgb(15, 20, 65);
-                text-decoration: none;
-                padding: 0;
-                z-index: 200 !important;
-                cursor: pointer;
-                opacity: 1; /* Will be overridden by display:none but kept for JS */
-                background-color: transparent;
-                /* display: none !important; */ /* Removed to make button visible */
+                /* All custom styles removed to allow user's CSS to take over. */
+                /* Browser default <button> styles may apply. */
             }
             #showLeaderboardBtn:hover {
-                filter: brightness(1.1);
-                background-color: transparent;
+                /* All custom styles removed. */
             }
             #canvas-container {
                 width: 100vw;


### PR DESCRIPTION
This commit addresses your feedback indicating you have implemented your own HTML and styling for a button with `id="showLeaderboardBtn"` which you intend to use for opening the leaderboard.

Changes in `index.html`:
- Removed the complex custom CSS rules previously applied to `#showLeaderboardBtn` (which included specific positioning, background images, text styling, z-index, opacity, etc.). The CSS rules for `#showLeaderboardBtn` and `#showLeaderboardBtn:hover` are now empty, allowing your defined styles or browser defaults to take precedence for its appearance and position.
- The JavaScript snippet that sets the `textContent` of `#showLeaderboardBtn` to "LEADERBOARD" remains, as this aligns with your specified button text.
- The CSS rules that hide the original campaign elements (`#campaign_button` and `#campaign_text`) remain in effect.

It is understood that the existing `playgama_leaderboard.js` script already attaches the necessary click event listener to the element with `id="showLeaderboardBtn"` to make it trigger the leaderboard display. No new event listeners are added by this commit for that functionality.

This change defers the styling of the leaderboard button to your own CSS implementation.