### PR TITLE
Fix: Restore full styling for repurposed Leaderboard button

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,11 +16,34 @@
                 background-position: center;
             }
             #showLeaderboardBtn {
-                /* All custom styles removed to allow user's CSS to take over. */
-                /* Browser default <button> styles may apply. */
+                position: absolute;
+                top: 58%;
+                left: 24%;
+                width: 52%;
+                max-width: 400px; /* From constrain-width fix */
+                min-width: 180px; /* From constrain-width fix */
+                height: 8%;
+                transform: translateY(-50%);
+                background-image: url(assets/Button_Y.png);
+                background-size: 100% 100%;
+                background-repeat: no-repeat;
+                background-position: center;
+                border: none;
+                text-align: center;
+                font-size: 2vh;
+                font-weight: bold;
+                line-height: 10vh; /* As per user, though height is 8% */
+                color: rgb(15, 20, 65);
+                text-decoration: none;
+                padding: 0;
+                z-index: 200 !important;
+                cursor: pointer;
+                opacity: 1;
+                background-color: transparent; /* Important for removing white background */
             }
             #showLeaderboardBtn:hover {
-                /* All custom styles removed. */
+                filter: brightness(1.1);
+                background-color: transparent; /* Ensure hover also transparent */
             }
             #canvas-container {
                 width: 100vw;


### PR DESCRIPTION
This commit addresses your feedback indicating that your desired CSS for the "LEADERBOARD" button (the repurposed `#showLeaderboardBtn`) was inadvertently removed in a previous step.

Changes in `index.html`:
- The CSS rules for `#showLeaderboardBtn` and `#showLeaderboardBtn:hover` have been fully restored to make it:
    - Appear as a yellow button using `assets/Button_Y.png` as its background.
    - Positioned and sized according to previously specified coordinates (`top: 58%`, `left: 24%`, `width: 52%`, `height: 8%`, etc.).
    - Include responsive width constraints (`min-width: 180px`, `max-width: 400px`).
    - Have `background-color: transparent` to ensure no white background from the button element itself.
    - Styled for the "LEADERBOARD" text (which is set by an existing script).
- The CSS rules hiding the original campaign elements (`#campaign_button`, `#campaign_text`) remain in effect.
- The script that sets the button's text to "LEADERBOARD" and attaches the `showLeaderboard()` click listener also remains in effect.

This change ensures the "LEADERBOARD" button has the intended visual appearance and position, functions correctly, and addresses the previous issues of incorrect styling and reported non-visibility of the leaderboard.